### PR TITLE
Req setuptools version with pkg_resources.extern

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ setup(
         'workdir>=0.3.1',
         'gitpython>=1.0.2',
         'requests>=2.10.0',
-        'six>=1.10.0'
+        'six>=1.10.0',
+        'setuptools>=28.8.0',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
Closes #5. 

This is the earliest version of setuptools that has `pkg_resources.extern`. Sources:

1. found earliest commit here, https://github.com/pypa/setuptools/commits/master/pkg_resources/extern
2. clicked through to details: https://github.com/pypa/setuptools/commit/9b985a9112d9be396adca6a1948076378c70cc34
3. note the version tag for that commit.