### PR TITLE
fix ruamel.yaml on 0.14.X for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'funcy>=1.4',
         'docopt>=0.6.2',
         'wheel>=0.26.0',
-        'ruamel.yaml>=0.11.3',
+        'ruamel.yaml>=0.11.3,<0.15',
         'pypandoc>=1.1.3',
         'twine>=1.6.5',
         'microcache>=0.2',


### PR DESCRIPTION
Thank you for using ruamel.yaml.

There will be API changes in the 0.15+ versions, that might lead to warnings that 
your users could see.
Therefore please release a version of your package with this change, so that it will not
automatically take the latest ruamel.yaml release.
